### PR TITLE
Cap CImGuiPack to 0.1.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ CImGuiPack_jll = "333409e9-af72-5310-9767-d6ad21a76a05"
 
 [compat]
 CEnum = "0.4"
-CImGuiPack_jll = "~0.1"
+CImGuiPack_jll = "=0.1.2"
 julia = "1.6"
 
 [extras]


### PR DESCRIPTION
CImGuiPack doesn't follow semver, so this ad-hot fix is needed.